### PR TITLE
Refactor: Optimize CheckAnimation widget and update its usage

### DIFF
--- a/lib/src/utils/widgets/check_animation/check_animation.dart
+++ b/lib/src/utils/widgets/check_animation/check_animation.dart
@@ -1,18 +1,16 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
-class CheckAnimation extends StatefulWidget{
-  ValueNotifier<bool> isValidPhoneNotifier;
-  CheckAnimation({super.key, required this.isValidPhoneNotifier});
-  @override
-  State<CheckAnimation> createState() => _CheckAnimation();
-}
 
-class _CheckAnimation extends State<CheckAnimation>{
+class CheckAnimation extends StatelessWidget{
+  ValueNotifier<bool> isValidPhoneNotifier;
+
+  CheckAnimation({required this.isValidPhoneNotifier});
+
   @override
   Widget build(BuildContext context) {
     // TODO: implement build
-      return ValueListenableBuilder(valueListenable: widget.isValidPhoneNotifier..value, builder: (context,isValid,_){
+      return ValueListenableBuilder(valueListenable: isValidPhoneNotifier..value, builder: (context,isValid,_){
         return AnimatedSwitcher(
           duration: const Duration(milliseconds: 500),
           transitionBuilder: (child, animation) {

--- a/lib/src/view/phone_auto_detect_view/phone_auto_detect_view.dart
+++ b/lib/src/view/phone_auto_detect_view/phone_auto_detect_view.dart
@@ -38,7 +38,6 @@ class _PhoneAutoDetectView extends State<PhoneAutoDetectView> {
 
   ValueNotifier<Country?> _country = ValueNotifier<Country?>(null);
 
-  CheckAnimation? checkAnimation;
 
 
   @override
@@ -55,7 +54,6 @@ class _PhoneAutoDetectView extends State<PhoneAutoDetectView> {
   /// - [context]: The build context.
   @override
   Widget build(BuildContext context) {
-    checkAnimation ??= CheckAnimation(isValidPhoneNotifier: widget.phoneValidator.isValidPhoneNotifier);
     return Padding(
         padding: const EdgeInsets.all(10),
         child:
@@ -109,12 +107,12 @@ class _PhoneAutoDetectView extends State<PhoneAutoDetectView> {
         enabled: true,
         selectionControls: null,
         decoration:country!=null?InputDecoration(
-          suffix: checkAnimation,
+          suffix: CheckAnimation(isValidPhoneNotifier: widget.phoneValidator.isValidPhoneNotifier),
           labelText: getPhovalidatorText(country, 'label', widget.phoneValidator.lang),
           prefixText: getPhovalidatorText(country, 'visualText', widget.phoneValidator.lang),
         ):InputDecoration(
             hintText: '## ### ###-####',
-          suffix:   checkAnimation
+          suffix:   CheckAnimation(isValidPhoneNotifier: widget.phoneValidator.isValidPhoneNotifier,)
         ),
         keyboardType: TextInputType.phone,
         controller: _phoneEditingController,

--- a/lib/src/view/phone_input_selector_view/phone_input_selector_view.dart
+++ b/lib/src/view/phone_input_selector_view/phone_input_selector_view.dart
@@ -1,3 +1,4 @@
+import 'package:cellphone_validator/src/utils/widgets/check_animation/check_animation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
@@ -84,16 +85,13 @@ class _PhoneInputSelectorView extends State<PhoneInputSelectorView> {
                 child: SizedBox(
                     height: 50,
                     child: getCountryDropdown())),
-            ValueListenableBuilder<bool>(
-                valueListenable: widget.phoneValidator.isValidPhoneNotifier,
-                builder: (context, isValid, _) {
-                  return Flexible(
+                   Flexible(
                       flex: 4,
                       child: Padding(
                           padding:
                              const EdgeInsets.only(left: 15, right: 15, bottom: 15),
-                          child: phoneTextField(isValid,widget.phoneValidator)));
-                })
+                          child: phoneTextField(widget.phoneValidator))
+                   )
           ],
         ));
   }
@@ -121,20 +119,7 @@ class _PhoneInputSelectorView extends State<PhoneInputSelectorView> {
         : [];
   }
 
-  Widget _isValidNumber(bool isValid){
-    return AnimatedSwitcher(
-      duration: const Duration(milliseconds: 500),
-      transitionBuilder: (child, animation) {
-        return ScaleTransition(
-          scale: animation,
-          child: child,
-        );
-      },
-      child: isValid
-          ? const Icon(key:Key('0'),Icons.check_circle_outline, color: Colors.green,)
-          : const Icon(key:Key('1'),Icons.cancel_outlined,color: Colors.red),
-    );
-  }
+
 
   void insertNumber(String text){
     widget.phoneValidator.checkPhone(text);
@@ -159,13 +144,13 @@ class _PhoneInputSelectorView extends State<PhoneInputSelectorView> {
     );
   }
 
-  TextField phoneTextField(bool isValid,PhoneValidator phoneValidator){
+  TextField phoneTextField(PhoneValidator phoneValidator){
    return TextField(
       decoration: InputDecoration(
         hintText: getPhovalidatorText(phoneValidator.country, 'mask',phoneValidator.lang),
         labelText: getPhovalidatorText(phoneValidator.country, 'countryName', phoneValidator.lang),
         prefix: Text(getPhovalidatorText(phoneValidator.country, 'visualText',phoneValidator.lang)),
-        suffix: _isValidNumber(isValid),
+        suffix: CheckAnimation(isValidPhoneNotifier:phoneValidator.isValidPhoneNotifier),
       ),
       keyboardType: TextInputType.phone,
       controller: _phoneEditingController,

--- a/lib/src/view/phone_text_view/phone_summary_view.dart
+++ b/lib/src/view/phone_text_view/phone_summary_view.dart
@@ -107,20 +107,6 @@ class _PhoneSummaryView extends State<PhoneSummaryView> {
         : [];
   }
 
-  Widget _isValidNumber(bool isValid){
-    return AnimatedSwitcher(
-      duration: const Duration(milliseconds: 500),
-      transitionBuilder: (child, animation) {
-        return ScaleTransition(
-          scale: animation,
-          child: child,
-        );
-      },
-      child: isValid
-          ? const Icon(key:Key('0'),Icons.check_circle_outline, color: Colors.green,)
-          : const Icon(key:Key('1'),Icons.cancel_outlined,color: Colors.red),
-    );
-  }
 
   void insertNumber(String text){
     widget.phoneValidator.checkPhone(text);


### PR DESCRIPTION
This commit refactors the `CheckAnimation` widget to be a `StatelessWidget` for better performance and simplicity. The widget is now instantiated directly within the `PhoneAutoDetectView` and `PhoneInputSelectorView` instead of being a stateful member.

The following changes were made:
- Modified `lib/src/utils/widgets/check_animation/check_animation.dart` to change `CheckAnimation` from a `StatefulWidget` to a `StatelessWidget`.
- Updated `lib/src/view/phone_auto_detect_view/phone_auto_detect_view.dart` to instantiate `CheckAnimation` directly in the build method.
- Updated `lib/src/view/phone_input_selector_view/phone_input_selector_view.dart` to use the refactored `CheckAnimation` widget and removed the local `_isValidNumber` method, streamlining the UI logic.
- Removed the unused `_isValidNumber` method from `lib/src/view/phone_text_view/phone_summary_view.dart` as its functionality is now covered by `CheckAnimation`.

Close #4 