### PR TITLE
Update version and save country in PhoneAutoDetectView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,3 +89,6 @@
 ## 2.0.1
 - Test all Countries
 - Fixed Countries mask
+
+## 2.0.2
+ - Save Country in PhoneValidator when it is a valid number in PhoneAutoDetectView

--- a/lib/src/view/phone_auto_detect_view/phone_auto_detect_view.dart
+++ b/lib/src/view/phone_auto_detect_view/phone_auto_detect_view.dart
@@ -61,6 +61,7 @@ class _PhoneAutoDetectView extends State<PhoneAutoDetectView> {
             valueListenable: widget.phoneValidator.isValidPhoneNotifier,
             builder: (context, isValid, _) {
               Country? country = widget.phoneValidator.getCountryByPhone(countries,_phoneEditingController.value.text);
+              widget.phoneValidator.setCountry(country!);
               return  Padding(
                   padding:
                   const EdgeInsets.only(left: 15, right: 15, bottom: 15),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cellphone_validator
 description: "A widget and helper for validation internation phone numbers"
-version: 2.0.1
+version: 2.0.2
 homepage: https://github.com/Decksplayer/phonevalidator
 repository: https://github.com/Decksplayer/phonevalidator
 


### PR DESCRIPTION
This commit updates the package version to 2.0.2 in `pubspec.yaml` and updates the `CHANGELOG.md` accordingly.

It also modifies `PhoneAutoDetectView` to save the detected country in the `PhoneValidator` when a valid phone number is entered.

Specific changes:
- `CHANGELOG.md`: Added entry for version 2.0.2.
- `pubspec.yaml`: Updated version from 2.0.1 to 2.0.2.
- `lib/src/view/phone_auto_detect_view/phone_auto_detect_view.dart`: Added a call to `widget.phoneValidator.setCountry(country!)` within the `ValueListenableBuilder` to save the detected country.